### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/dante-telegram.yaml
+++ b/.github/workflows/dante-telegram.yaml
@@ -25,7 +25,7 @@ jobs:
           curl -sL https://github.com/andromedarabbit/docker-dante-telegram/archive/master.tar.gz | tar xz
 
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ github.repository_owner }}/${{ github.workflow }}
           registry: ghcr.io

--- a/.github/workflows/ikev2-vpn-server.yaml
+++ b/.github/workflows/ikev2-vpn-server.yaml
@@ -24,7 +24,7 @@ jobs:
       run: |
         curl -sL https://github.com/gaomd/docker-ikev2-vpn-server/archive/master.tar.gz | tar xz
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: unchartedsky/ikev2-vpn-server
         registry: ghcr.io

--- a/.github/workflows/secret-sync-operator.yaml
+++ b/.github/workflows/secret-sync-operator.yaml
@@ -24,7 +24,7 @@ jobs:
         run: |
           curl -sL https://github.com/unchartedsky/secret-sync-operator/archive/master.tar.gz | tar xz
       - name: Publish to Registry
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: unchartedsky/secret-sync-operator
           registry: ghcr.io


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore